### PR TITLE
Set wifi-DHCP hostname to sensorname.

### DIFF
--- a/bruh_mqtt_multisensor_github/bruh_mqtt_multisensor_github.ino
+++ b/bruh_mqtt_multisensor_github/bruh_mqtt_multisensor_github.ino
@@ -58,7 +58,7 @@ const char* off_cmd = "OFF";
 
 
 /**************************** FOR OTA **************************************************/
-#define SENSORNAME "sensornode1"
+#define SENSORNAME "sensornode1" // This also sets the wifi/dhcp hostname
 #define OTApassword "YouPassword" // change this to whatever password you want to use when you upload OTA
 int OTAport = 8266;
 
@@ -206,6 +206,7 @@ void setup_wifi() {
   Serial.println(wifi_ssid);
 
   WiFi.mode(WIFI_STA);
+  WiFi.hostname(SENSORNAME);
   WiFi.begin(wifi_ssid, wifi_password);
 
   while (WiFi.status() != WL_CONNECTED) {


### PR DESCRIPTION
By using 

`WiFi.hostname(SENSORNAME);`

we can easily identify the sensors in the DHCP scope or wifi host list within the network. Rather than just seeing esp_MAC


![image](https://user-images.githubusercontent.com/22154114/27868567-2615c508-616b-11e7-9fa8-7054a0c3b7f5.png)
